### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -649,7 +649,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -718,14 +718,14 @@ dependencies = [
 
 [[package]]
 name = "sericom"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "clap",
  "crossterm",
  "miette",
  "serial2-tokio",
- "sericom-core",
+ "sericom-core 0.4.0",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -735,6 +735,23 @@ dependencies = [
 [[package]]
 name = "sericom-core"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02d8a6d29b40af42b75e4385cc098bc601a14f12ec26afd668b1414961f17c7"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "miette",
+ "serde",
+ "serial2-tokio",
+ "thiserror 2.0.16",
+ "tokio",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "sericom-core"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "crossterm",

--- a/sericom-core/CHANGELOG.md
+++ b/sericom-core/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/tkatter/sericom/compare/sericom-core/v0.4.0...sericom-core/v0.5.0) - 2025-09-13
+
+### Changed
+
+- Swap git-cliff for release-plz
+- git-cliff configuration
+
+### Fixed
+
+- *(ascii)* Fixed processing of ascii highlight & bold escape sequences
+- *(configs)* [**breaking**] Removed hl_fg and hl_bg configurations to use the inverse
+
 ## [0.4.0](https://github.com/tkatter/sericom/releases/tag/sericom-core/v0.4.0) - 2025-09-11
 
 ### Added

--- a/sericom-core/Cargo.toml
+++ b/sericom-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sericom-core"
 description = "The underlying library for sericom"
-version = "0.4.0"
+version = "0.5.0"
 license = "MIT"
 readme = "README.md"
 edition.workspace = true

--- a/sericom/CHANGELOG.md
+++ b/sericom/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/tkatter/sericom/compare/sericom/v0.5.0...sericom/v0.5.1) - 2025-09-13
+
+### Changed
+
+- Added cargo-dist ci for binary creations
+- Swap git-cliff for release-plz
+- git-cliff configuration
+
+### Fixed
+
+- *(tracing)* Fixed compatability between Windows and Linux serial ports as paths
+- *(configs)* [**breaking**] Removed hl_fg and hl_bg configurations to use the inverse
+
 ## [0.5.0](https://github.com/tkatter/sericom/releases/tag/sericom/v0.5.0) - 2025-09-11
 
 ### Added

--- a/sericom/Cargo.toml
+++ b/sericom/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sericom"
 authors = ["Thomas Katter <tjkatter@gmail.com"]
-version = "0.5.0"
+version = "0.5.1"
 description = "CLI tool for communicating with devices over a serial connection."
 documentation = "https://github.com/tkatter/sericom"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `sericom-core`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `sericom`: 0.5.0 -> 0.5.1

### ⚠ `sericom-core` breaking changes

```text
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field hl_fg of struct Appearance, previously in file /tmp/.tmpsTed8L/sericom-core/src/configs/appearance.rs:23
  field hl_bg of struct Appearance, previously in file /tmp/.tmpsTed8L/sericom-core/src/configs/appearance.rs:25
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sericom-core`

<blockquote>


## [0.5.0](https://github.com/tkatter/sericom/compare/sericom-core/v0.4.0...sericom-core/v0.5.0) - 2025-09-13

### Changed

- Swap git-cliff for release-plz
- git-cliff configuration

### Fixed

- *(ascii)* Fixed processing of ascii highlight & bold escape sequences
- *(configs)* [**breaking**] Removed hl_fg and hl_bg configurations to use the inverse
</blockquote>

## `sericom`

<blockquote>

## [0.5.1](https://github.com/tkatter/sericom/compare/sericom/v0.5.0...sericom/v0.5.1) - 2025-09-13

### Changed

- Added cargo-dist ci for binary creations
- Swap git-cliff for release-plz
- git-cliff configuration

### Fixed

- *(tracing)* Fixed compatability between Windows and Linux serial ports as paths
- *(configs)* [**breaking**] Removed hl_fg and hl_bg configurations to use the inverse
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).