### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -642,7 +642,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "sericom"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "chrono",
  "clap",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "sericom-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "crossterm",

--- a/sericom-core/CHANGELOG.md
+++ b/sericom-core/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/tkatter/sericom/compare/sericom-core/v0.5.0...sericom-core/v0.6.0) - 2025-09-25
+
+### Added
+
+- *(exit-script)* added ability to run script after file is written
+
+### Changed
+
+- *(clippy)* Change EscapePart derive impl for clippy CI
+
+### Documentation
+
+- *(exit-script)* Added docs for new stuff
+
+### Fixed
+
+- *(exit-script)* Windows compatibility for exit-scripts
+
+### Chore
+
+- *(deps)* bump serde from 1.0.225 to 1.0.226 ([#23](https://github.com/tkatter/sericom/pull/23))
+- *(deps)* bump toml from 0.9.6 to 0.9.7 ([#21](https://github.com/tkatter/sericom/pull/21))
+- *(deps)* bump serde from 1.0.224 to 1.0.225 ([#20](https://github.com/tkatter/sericom/pull/20))
+- *(deps)* bump toml from 0.9.5 to 0.9.6 ([#19](https://github.com/tkatter/sericom/pull/19))
+- *(deps)* bump serde from 1.0.219 to 1.0.224 ([#18](https://github.com/tkatter/sericom/pull/18))
+
 ## [0.5.0](https://github.com/tkatter/sericom/compare/sericom-core/v0.4.0...sericom-core/v0.5.0) - 2025-09-13
 
 ### Changed

--- a/sericom-core/Cargo.toml
+++ b/sericom-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sericom-core"
 description = "The underlying library for sericom"
-version = "0.5.0"
+version = "0.6.0"
 license = "MIT"
 readme = "README.md"
 edition.workspace = true

--- a/sericom/CHANGELOG.md
+++ b/sericom/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/tkatter/sericom/compare/sericom/v0.5.2...sericom/v0.5.3) - 2025-09-25
+
+### Documentation
+
+- *(exit-script)* Added docs for new stuff
+- *(other)* Update docs for windows exit-script
+- *(other)* Updated README and config example files
+
+### Chore
+
+- *(deps)* bump clap from 4.5.47 to 4.5.48 ([#22](https://github.com/tkatter/sericom/pull/22))
+
+### Feat
+
+- *(exit-script)* ability to specify a script to run after writing a file
+
 ## [0.5.2](https://github.com/tkatter/sericom/compare/sericom/v0.5.1...sericom/v0.5.2) - 2025-09-13
 
 ### Changed

--- a/sericom/Cargo.toml
+++ b/sericom/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sericom"
 authors = ["Thomas Katter <tjkatter@gmail.com"]
-version = "0.5.2"
+version = "0.5.3"
 description = "CLI tool for communicating with devices over a serial connection."
 documentation = "https://github.com/tkatter/sericom"
 license = "GPL-3.0-or-later"
@@ -29,7 +29,7 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 [dependencies]
 clap = { version = "4.5.48", features = ["derive"] }
-sericom-core = { version = "0.5.0", path = "../sericom-core" }
+sericom-core = { version = "0.6.0", path = "../sericom-core" }
 tracing-appender = "0.2"
 tracing-subscriber = "0.3.20"
 chrono.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sericom-core`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `sericom`: 0.5.2 -> 0.5.3

### ⚠ `sericom-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Defaults.exit_script in /tmp/.tmpV5Ee2L/sericom/sericom-core/src/configs/defaults.rs:26
  field ConfigOverride.exit_script in /tmp/.tmpV5Ee2L/sericom/sericom-core/src/configs/mod.rs:106
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sericom-core`

<blockquote>


## [0.6.0](https://github.com/tkatter/sericom/compare/sericom-core/v0.5.0...sericom-core/v0.6.0) - 2025-09-25

### Added

- *(exit-script)* added ability to run script after file is written

### Changed

- *(clippy)* Change EscapePart derive impl for clippy CI

### Documentation

- *(exit-script)* Added docs for new stuff

### Fixed

- *(exit-script)* Windows compatibility for exit-scripts

### Chore

- *(deps)* bump serde from 1.0.225 to 1.0.226 ([#23](https://github.com/tkatter/sericom/pull/23))
- *(deps)* bump toml from 0.9.6 to 0.9.7 ([#21](https://github.com/tkatter/sericom/pull/21))
- *(deps)* bump serde from 1.0.224 to 1.0.225 ([#20](https://github.com/tkatter/sericom/pull/20))
- *(deps)* bump toml from 0.9.5 to 0.9.6 ([#19](https://github.com/tkatter/sericom/pull/19))
- *(deps)* bump serde from 1.0.219 to 1.0.224 ([#18](https://github.com/tkatter/sericom/pull/18))
</blockquote>

## `sericom`

<blockquote>

## [0.5.3](https://github.com/tkatter/sericom/compare/sericom/v0.5.2...sericom/v0.5.3) - 2025-09-25

### Documentation

- *(exit-script)* Added docs for new stuff
- *(other)* Update docs for windows exit-script
- *(other)* Updated README and config example files

### Chore

- *(deps)* bump clap from 4.5.47 to 4.5.48 ([#22](https://github.com/tkatter/sericom/pull/22))

### Feat

- *(exit-script)* ability to specify a script to run after writing a file
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).